### PR TITLE
Switch to 8-bit & 24-bit colour codes

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ Optionally, you can add/modify the `HKLM | HKCU \Software\Microsoft\Command Proc
 This way, any instance of a Command Prompt window will have the Powerline set up.
 
 However, do note that modifying the AutoRun key is not recommended.
-Although code contains checks to ensure that `init.cmd` is not called recursively and will only run on an interactive window,
+Although code contains checks to ensure that `init.cmd` will only run on an interactive window,
 there may still be bugs due to the nature of the AutoRun key.
 
 > Additionally, you should modify or clear out the content of [`header.cmd`](#headercmd),
@@ -80,16 +80,23 @@ You can add/edit individual profiles and sections, including the default profile
 #### Profiles
 
 - `segments`: A space-separated list of `segments:color` or `"text":color`.
-  - Multiple segment definitions can be joined with the `-` delimiter (without the prefix "`s_`").
-  - Text can be entered directly using double quotes instead of a segment name.
-  - Two digits of 0-7 for foreground and background 3-bit colour codes.
-  Each digit can be followed by an optional `+` to use the brighter 4-bit colours.
-  See [wikipedia](https://en.wikipedia.org/wiki/ANSI_escape_code#3-bit_and_4-bit).
+  - `segment`: Specify the segment name(s) without the prefix "`s_`". Multiple segments can be joined with the `-` delimiter.
 
-  > For example, `cwd-compact:04+` means to apply segments `s_cwd` and `s_compact` in that order, with a black foreground (30) and a bright blue background (104).
+  - `"text"`: Alternatively, text can be entered directly using double quotes.
+  However, this direct text cannot contain any special characters or variables holding special characters.
 
-  - Colour can be ommited, in which case it defaults to either the colours specified in the segment definition, or `00`.
-- `separator`: A character to append at the end of each section. For example, the right-facing-triangle character `U+E0B0`.
+  - `color`: A colour code pair for foreground and background.
+    See [wikipedia](https://en.wikipedia.org/wiki/ANSI_escape_code#8-bit).
+    - Standard: A pair of 1-digit hexadecimal numbers &mdash; 0~7.
+    - High intensity: A pair of 1-digit hexadecimal numbers &mdash; 8~F.
+    - Grayscale: A pair of 2-digit octal numbers from black to white &mdash; 00~27.
+    - 666 cube: A pair of 3-digit heximal (base 6) numbers of RGB &mdash; 000~555.
+    - 24-bit: A pair of 6-digit hexadecimal numbers of RGB &mdash; 000000~FFFFFF
+
+    Colour can be ommited, in which case it defaults to either the colours specified in the segment definition, or `00`.
+
+- `separator`: A character to append at the end of each section. For example, the right-facing-triangle character `U+E0B0` (Powerline font symbol).
+
 - `margin`: String to append to the end of the powerline. Usually a space, or a newline followed by a '>' or '$'. Use the escape characters of `PROMPT`.
 See [microsoft docs](https://learn.microsoft.com/en-us/windows-server/administration/windows-commands/prompt#remarks).
 
@@ -122,13 +129,13 @@ They need to have their `%`s doubled to escape evaluation on initialisation.
   Thus,
   - `var` can contain the options for `for /f`.
 
-    >For example, `var="tokens=*" %%i`.
+    >For example, `var="tokens=1,2" %%i`.
 
     Note that `%` needs to be doubled within the batch script.
-  - `cmd` needs to be surrounded by single quotes `'...'` (or backticks `` `...` `` if the option `"usebackq"` is supplied in `var`).
+  - `cmd` needs to be surrounded by single quotes `'...'`, or backticks `` `...` `` if the option `"usebackq"` is supplied in `var`.
   - `cmd` needs to have special characters (``%^&<>|'`,;=()!``) escaped.
   - `text` can then use the introduced variable(s).
-    > For example, `text=$S%%i$S`.
+    > For example, `text=%%i-%%j`.
 
 ## How it works
 

--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ They need to have their `%`s doubled to escape evaluation on initialisation.
 - Dynamic evaluations have three parts: variable, command and text. They are essentially evaluated by the `for /f` command.
 
   ```cmd
-  for /f %var% in (%cmd%) do ...%text%
+  for /f %var% in (!cmd!) do ...%text%
   ```
 
   Thus,
@@ -126,11 +126,7 @@ They need to have their `%`s doubled to escape evaluation on initialisation.
 
     Note that `%` needs to be doubled within the batch script.
   - `cmd` needs to be surrounded by single quotes `'...'` (or backticks `` `...` `` if the option `"usebackq"` is supplied in `var`).
-  - `cmd` needs to have special characters (``%^&<>|'`,;=()!``) escaped **twice**.
-    > For example,  
-    `set "cmd='git branch 2^>nul'"` or  
-    `set cmd='git branch 2^^^>nul'`, instead of  
-    `set cmd='git branch 2^>nul'` (will be syntax error on evaluation).
+  - `cmd` needs to have special characters (``%^&<>|'`,;=()!``) escaped.
   - `text` can then use the introduced variable(s).
     > For example, `text=$S%%i$S`.
 

--- a/init.cmd
+++ b/init.cmd
@@ -65,8 +65,8 @@ exit /b
 :build_segment ("separator", segment) -> PL_I, PL_P[], PL_V[], PL_C[]
     setlocal EnableDelayedExpansion
 
-    set fore=5;0
-    set back=5;0
+    set fore=
+    set back=
     set var=
     set cmd=
     set text=
@@ -114,20 +114,44 @@ exit /b
     goto :eof
 
 :color ([value]) -> fore, back
-    if "%1" == "" goto :eof
-    set back=%1
-    if "%back:~1,1%" == "+" (
-        set /a fore=%back:~0,1% + 8
-        set back=%back:~2%
-    ) else (
-        set /a fore=0x%back:~0,1%
-        set back=%back:~1%
+    setlocal EnableDelayedExpansion
+
+    set value=#%1
+    if "%value:~3,1%" == "" (
+        set /a fore=0x0%value:~1,1%
+        set /a back=0x0%value:~2,1%
+        goto :color_8bit
     )
-    if "%back:~1,1%" == "+" (
-        set /a back=%back:~0,1% + 8
-    ) else (
-        set /a back=0x%back:~0,1%
+    if "%value:~5,1%" == "" (
+        set /a fore=232+0%value:~1,2%
+        set /a back=232+0%value:~3,2%
+        rem if !fore! gtr 255 ( set fore=255 ) else if !fore! lss 232 ( set fore=232 )
+        rem if !back! gtr 255 ( set back=255 ) else if !back! lss 232 ( set back=232 )
+        goto :color_8bit
     )
-    set fore=5;%fore%
-    set back=5;%back%
+    if "%value:~7,1%" == "" (
+        set /a fore=16 + 36 * 0%value:~1,1% + 6 * 0%value:~2,1% + 0%value:~3,1%
+        set /a back=16 + 36 * 0%value:~4,1% + 6 * 0%value:~5,1% + 0%value:~6,1%
+        rem if !fore! gtr 231 ( set fore=231 ) else if !fore! lss 16 ( set fore=16 )
+        rem if !back! gtr 231 ( set back=231 ) else if !back! lss 16 ( set back=16 )
+        goto :color_8bit
+    )
+
+    set /a fr=0x0%value:~1,2%
+    set /a fg=0x0%value:~3,2%
+    set /a fb=0x0%value:~5,2%
+    set /a br=0x0%value:~7,2%
+    set /a bg=0x0%value:~9,2%
+    set /a bb=0x0%value:~11,2%
+    ( endlocal
+        set fore=2;%fr%;%fg%;%fb%
+        set back=2;%br%;%bg%;%bb%
+    )
+    goto :eof
+
+    :color_8bit
+    ( endlocal
+        set fore=5;%fore%
+        set back=5;%back%
+    )
     goto :eof

--- a/init.cmd
+++ b/init.cmd
@@ -65,8 +65,8 @@ exit /b
 :build_segment ("separator", segment) -> PL_I, PL_P[], PL_V[], PL_C[]
     setlocal EnableDelayedExpansion
 
-    set fore=0
-    set back=0
+    set fore=5;0
+    set back=5;0
     set var=
     set cmd=
     set text=

--- a/init.cmd
+++ b/init.cmd
@@ -125,15 +125,11 @@ exit /b
     if "%value:~5,1%" == "" (
         set /a fore=232+0%value:~1,2%
         set /a back=232+0%value:~3,2%
-        rem if !fore! gtr 255 ( set fore=255 ) else if !fore! lss 232 ( set fore=232 )
-        rem if !back! gtr 255 ( set back=255 ) else if !back! lss 232 ( set back=232 )
         goto :color_8bit
     )
     if "%value:~7,1%" == "" (
         set /a fore=16 + 36 * 0%value:~1,1% + 6 * 0%value:~2,1% + 0%value:~3,1%
         set /a back=16 + 36 * 0%value:~4,1% + 6 * 0%value:~5,1% + 0%value:~6,1%
-        rem if !fore! gtr 231 ( set fore=231 ) else if !fore! lss 16 ( set fore=16 )
-        rem if !back! gtr 231 ( set back=231 ) else if !back! lss 16 ( set back=16 )
         goto :color_8bit
     )
 

--- a/init.cmd
+++ b/init.cmd
@@ -78,10 +78,6 @@ exit /b
         call :color %%j
     )
 
-    set /a f=%fore% + 30
-    set /a t=%back% + 30
-    set /a b=%back% + 40
-
     if defined var if defined cmd (
         if defined PL_P[%PL_I%] (
             set /a PL_I+=1
@@ -91,15 +87,15 @@ exit /b
 
     if not defined PL_P[0] (
         if defined text (
-            set "p=$E[%f%;%b%m%text%$E[%t%;"
+            set "p=$E[38;%fore%;48;%back%m%text%$E[38;%back%;"
         ) else (
-            set "p=$E[%t%;"
+            set "p=$E[38;%back%;"
         )
     ) else (
         if defined text (
-            set "p=!PL_P[%i%]!%b%m%~1$E[%f%m%text%$E[%t%;"
+            set "p=!PL_P[%i%]!48;%back%m%~1$E[38;%fore%m%text%$E[38;%back%;"
         ) else (
-            set "p=!PL_P[%i%]!%b%m%~1$E[%t%;"
+            set "p=!PL_P[%i%]!48;%back%m%~1$E[38;%back%;"
         )
     )
 
@@ -119,15 +115,17 @@ exit /b
     if "%1" == "" goto :eof
     set back=%1
     if "%back:~1,1%" == "+" (
-        set fore=6%back:~0,1%
+        set /a fore=%back:~0,1% + 8
         set back=%back:~2%
     ) else (
-        set fore=%back:~0,1%
+        set /a fore=0x%back:~0,1%
         set back=%back:~1%
     )
     if "%back:~1,1%" == "+" (
-        set back=6%back:~0,1%
+        set /a back=%back:~0,1% + 8
     ) else (
-        set back=%back:~0,1%
+        set /a back=0x%back:~0,1%
     )
+    set fore=5;%fore%
+    set back=5;%back%
     goto :eof

--- a/styles.cmd
+++ b/styles.cmd
@@ -124,12 +124,12 @@ goto :eof
 
 :s_git
 set var="tokens=*" %%i
-set "cmd='git branch --show-current 2^>nul'"
+set cmd='git branch 2^>nul ^| findstr /bc:"* "'
 set text=$S$S%%i$S
 goto :eof
 
 rem :s_my_script
-rem set var="tokens=*" %%i
+rem set var="delims=" %%i
 rem set cmd='"%~dp0scripts\my_script.cmd"'
 rem set text=$S%%i$S
 rem goto :eof

--- a/styles.cmd
+++ b/styles.cmd
@@ -6,9 +6,9 @@ rem =============================================
 
 :p_default
 net session 1>nul 2>nul && (
-    set segments=cwd:01+ git:03+
+    set segments=cwd:01 git:03
 ) || (
-    set segments=cwd:06+ git:03+
+    set segments=cwd:06 git:03
 )
 set "separator="
 set "margin=$S"
@@ -51,19 +51,15 @@ set "margin=$S"
 goto :eof
 
 :p_-user
-set segments=user:02+ %segments%
+set segments=user:02 %segments%
 goto :eof
 
 :p_-os
-set segments=os:05+ %segments%
+set segments=os:0D %segments%
 goto :eof
 
 :p_-pad
 set segments="" %segments%
-goto :eof
-
-:p_-dark
-set segments=%segments:+=%
 goto :eof
 
 :p_-sep-round
@@ -123,9 +119,9 @@ set text=$S%%SESSIONNAME%%$S
 goto :eof
 
 :s_git
-set var="tokens=*" %%i
+set var="tokens=1,*" %%i
 set cmd='git branch 2^>nul ^| findstr /bc:"* "'
-set text=$S$S%%i$S
+set text=$S$S%%j$S
 goto :eof
 
 rem :s_my_script

--- a/update.cmd
+++ b/update.cmd
@@ -16,7 +16,7 @@
     @set "var=!PL_V[%1]!"
     @set "cmd=!PL_C[%1]!"
     @set "text=!PL_P[%1]!"
-    @for /f %var% in (%cmd%) do @(
+    @for /f %var% in (!cmd!) do @(
         set "PROMPT=%PROMPT%%text%"
     )
     @goto :eof


### PR DESCRIPTION
- Supports 4 different types of colour formats (standard & high intensity, grayscale, 666 cube, 24-bit).
- Old colour format `0+` is no longer supported (breaking change).
- Delayed expansion of `cmd` so that it does not need to be escaped twice.
- `styles.cmd` file updated accordingly (breaking change).